### PR TITLE
Load spec files from resource path if it's provided

### DIFF
--- a/build/tasks/spec-task.coffee
+++ b/build/tasks/spec-task.coffee
@@ -41,8 +41,7 @@ module.exports = (grunt) ->
     done = @async()
     startTime = Date.now()
     runCoreSpecs (error, results) ->
-      console.log error
-      console.log results
       elapsedTime = Math.round((Date.now() - startTime) / 100) / 10
       grunt.log.ok("Total spec time: #{elapsedTime}s")
-      done()
+      grunt.log.error("[Error]".red + " core spec failed") if results
+      done(!results)

--- a/spec/spec-bootstrap.coffee
+++ b/spec/spec-bootstrap.coffee
@@ -7,6 +7,7 @@ app = remote.require 'app'
 
 # Start the crash reporter before anything else.
 require('crash-reporter').start(productName: @pkgJson.name, companyName: 'atom-shell-starter')
+specRootPath = path.resolve(global.loadSettings.resourcePath, 'spec/')
 
 if global.loadSettings.exitWhenDone
   jasmineFn = require 'jasmine'
@@ -21,9 +22,6 @@ if global.loadSettings.exitWhenDone
   jasmineEnv = jasmine.getEnv()
   jasmineEnv.addReporter(reporter)
 
-  specRootPath = 'spec/'
-  if global.loadSettings.resourcePath
-    specRootPath = path.resolve(global.loadSettings.resourcePath, specRootPath)
   for specFilePath in fs.listTreeSync(specRootPath) when /-spec\.(coffee|js)$/.test specFilePath
     require specFilePath
 
@@ -38,9 +36,6 @@ else
   require '../vendor/jasmine/lib/jasmine-2.1.3/jasmine-html'
   require '../vendor/jasmine/lib/jasmine-2.1.3/boot'
 
-  specRootPath = 'spec/'
-  if global.loadSettings.resourcePath
-    specRootPath = path.resolve(global.loadSettings.resourcePath, specRootPath)
   for specFilePath in fs.listTreeSync(specRootPath) when /-spec\.(coffee|js)$/.test specFilePath
     require specFilePath
 

--- a/spec/spec-bootstrap.coffee
+++ b/spec/spec-bootstrap.coffee
@@ -21,7 +21,10 @@ if global.loadSettings.exitWhenDone
   jasmineEnv = jasmine.getEnv()
   jasmineEnv.addReporter(reporter)
 
-  for specFilePath in fs.listTreeSync('spec/') when /-spec\.(coffee|js)$/.test specFilePath
+  specRootPath = 'spec/'
+  if global.loadSettings.resourcePath
+    specRootPath = path.resolve(global.loadSettings.resourcePath, specRootPath)
+  for specFilePath in fs.listTreeSync(specRootPath) when /-spec\.(coffee|js)$/.test specFilePath
     require specFilePath
 
   jasmineEnv.execute()
@@ -35,7 +38,10 @@ else
   require '../vendor/jasmine/lib/jasmine-2.1.3/jasmine-html'
   require '../vendor/jasmine/lib/jasmine-2.1.3/boot'
 
-  for specFilePath in fs.listTreeSync('spec/') when /-spec\.(coffee|js)$/.test specFilePath
+  specRootPath = 'spec/'
+  if global.loadSettings.resourcePath
+    specRootPath = path.resolve(global.loadSettings.resourcePath, specRootPath)
+  for specFilePath in fs.listTreeSync(specRootPath) when /-spec\.(coffee|js)$/.test specFilePath
     require specFilePath
 
   window.jasmineExecute()

--- a/src/browser/application.coffee
+++ b/src/browser/application.coffee
@@ -37,7 +37,6 @@ class Application
   #   :devMode - Boolean to determine if the application is running in dev mode.
   #   :test - Boolean to determine if the application is running in test mode.
   #   :exitWhenDone - Boolean to determine whether to automatically exit.
-  #   :specDirectory - The directory to load specs from.
   #   :logfile - The file path to log output to.
   openWithOptions: (options) ->
     {test} = options
@@ -57,9 +56,8 @@ class Application
   # options -
   #   :exitWhenDone - Boolean to determine whether to automatically exit.
   #   :resourcePath - The path to include specs from.
-  #   :specDirectory - The directory to load specs from.
   #   :logfile - The file path to log output to.
-  openSpecsWindow: ({exitWhenDone, resourcePath, specDirectory, logFile}) ->
+  openSpecsWindow: ({exitWhenDone, resourcePath, logFile}) ->
     if resourcePath isnt @resourcePath and not fs.existsSync(resourcePath)
       resourcePath = @resourcePath
 
@@ -70,7 +68,7 @@ class Application
 
     isSpec = true
     devMode = true
-    new AppWindow({bootstrapScript, exitWhenDone, resourcePath, isSpec, devMode, specDirectory, logFile})
+    new AppWindow({bootstrapScript, exitWhenDone, resourcePath, isSpec, devMode, logFile})
 
   # Opens up a new {AppWindow} and runs the application.
   #
@@ -79,7 +77,6 @@ class Application
   #   :devMode - Boolean to determine if the application is running in dev mode.
   #   :test - Boolean to determine if the application is running in test mode.
   #   :exitWhenDone - Boolean to determine whether to automatically exit.
-  #   :specDirectory - The directory to load specs from.
   #   :logfile - The file path to log output to.
   openWindow: (options) ->
     appWindow = new AppWindow(options)

--- a/src/browser/application.coffee
+++ b/src/browser/application.coffee
@@ -64,7 +64,7 @@ class Application
       resourcePath = @resourcePath
 
     try
-      bootstrapScript = require.resolve(path.resolve(global.devResourcePath, 'spec', 'spec-bootstrap'))
+      bootstrapScript = require.resolve(path.resolve(resourcePath, 'spec', 'spec-bootstrap'))
     catch error
       bootstrapScript = require.resolve(path.resolve(__dirname, '..', '..', 'spec', 'spec-bootstrap'))
 

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -24,7 +24,6 @@ parseCommandLine = ->
     .alias('h', 'help').boolean('h').describe('h', 'Print this usage message.')
     .alias('l', 'log-file').string('l').describe('l', 'Log all output to file.')
     .alias('r', 'resource-path').string('r').describe('r', 'Set the path to the App source directory and enable dev-mode.')
-    .alias('s', 'spec-directory').string('s').describe('s', 'Set the directory from which to run package specs (default: Atom\'s spec directory).')
     .alias('t', 'test').boolean('t').describe('t', 'Run the specified specs and exit with error code on failures.')
     .alias('v', 'version').boolean('v').describe('v', 'Print the version.')
 
@@ -45,21 +44,11 @@ parseCommandLine = ->
   devMode = args['dev']
   test = args['test']
   exitWhenDone = test
-  specDirectory = args['spec-directory']
   logFile = args['log-file']
 
   if args['resource-path']
     devMode = true
     resourcePath = args['resource-path']
-  else
-    # Set resourcePath based on the specDirectory if running specs on atom core
-    if specDirectory?
-      packageDirectoryPath = path.join(specDirectory, '..')
-      packageManifestPath = path.join(packageDirectoryPath, 'package.json')
-      if fs.statSyncNoException(packageManifestPath)
-        try
-          packageManifest = JSON.parse(fs.readFileSync(packageManifestPath))
-          resourcePath = packageDirectoryPath if packageManifest.name is 'atom'
 
     if devMode
       resourcePath ?= global.devResourcePath
@@ -69,7 +58,7 @@ parseCommandLine = ->
 
   resourcePath = path.resolve(resourcePath)
 
-  {resourcePath, devMode, test, exitWhenDone, specDirectory, logFile}
+  {resourcePath, devMode, test, exitWhenDone, logFile}
 
 setupCoffeeScript = ->
   CoffeeScript = null


### PR DESCRIPTION
This lets you update specs without having to re-build everything and
leads to a much faster development cycle. Fixes issue #67.